### PR TITLE
Update and rename 868mhz decoder.js to decoder.js

### DIFF
--- a/Adeunis/decoder.js
+++ b/Adeunis/decoder.js
@@ -1,4 +1,5 @@
-// TTN decoder function for the Adeunis Field Test Device LoRaWAN
+// Helium decoder function for the Adeunis Field Test Device LoRaWAN
+// working with EU868 and US915 Firmware
 // https://www.adeunis.com/en/produit/ftd-868-915-2/
 
 function Decoder(bytes, port) {


### PR DESCRIPTION
Removed 868Mhz designation as it works well with both versions