### PR TITLE
Update Decoder v1_6.js

### DIFF
--- a/Dragino/LGT92/Decoder v1_6.js
+++ b/Dragino/LGT92/Decoder v1_6.js
@@ -59,7 +59,7 @@ return {
 latitude: latitude,
 longitude: longitude,
 roll: roll,
-ritch:pitch,
+pitch:pitch,
 battery:batV,
 ALARM_status:alarm,
 MD:motion_mode,


### PR DESCRIPTION
Typo correction of “ritch” to “pitch” in return