### PR TITLE
Create RAK4631-LPWAN-Tracker-Google-Sheet

### DIFF
--- a/RAK4631-LPWAN-Tracker-Google-Sheet
+++ b/RAK4631-LPWAN-Tracker-Google-Sheet
@@ -1,0 +1,19 @@
+function Decoder(bytes, port) {
+  // TODO: Transform bytes to decoded payload below
+    var sensor = {};
+    sensor.latitude  = (bytes[0] | bytes[1] << 8 | bytes[2] << 16 | bytes[3] << 24 | (bytes[3] & 0x80 ? 0xFF << 24 : 0)) / 100000;
+    sensor.longitude = (bytes[4] | bytes[5] << 8 | bytes[6] << 16 | bytes[7] << 24 | (bytes[7] & 0x80 ? 0xFF << 24 : 0)) / 100000;
+    sensor.altitude  = (bytes[8] | bytes[9] << 8 | (bytes[9] & 0x80 ? 0xFF << 16 : 0));
+    sensor.accuracy  = (bytes[10] | bytes[11] << 8 | (bytes[9] & 0x80 ? 0xFF << 16 : 0)) / 100;
+    sensor.battery   = (bytes[12] | bytes[13] << 8 | (bytes[9] & 0x80 ? 0xFF << 16 : 0)) / 1000;
+  var decodedPayload = {
+    "latitude": sensor.latitude,
+    "longitude": sensor.longitude,
+    "altitude": sensor.altitude,
+    "accuracy": sensor.accuracy,
+    "battery": sensor.battery
+  };
+  // END TODO
+
+  return Serialize(decodedPayload)
+}


### PR DESCRIPTION
This is a decoder function for the Google Sheets Integration.  This will send the GPS tracking data to a Google Sheet and can be used simultaneously with the Helium Mapper Integration.